### PR TITLE
Make the automata package needed and do not load it inside function

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -65,7 +65,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.8",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
+  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ]
+                         , [ "automata", ">= 1.13" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),


### PR DESCRIPTION
This is "the recommended way" to load dependencies.

Once I have finished the linear algebra bits I can also look at using the `digraphs` package instead of automata, which seems to be the more canonical solution to graph problems.
